### PR TITLE
Added debug output for captured variables

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -130,6 +130,7 @@ function createRequest(requestSpec, config, ee) {
           if (params.capture) {
             let capturedVal = jsonpath.eval(r, params.capture.json)[0];
             context.vars[params.capture.as] = capturedVal;
+            debug('captured var %s = %s', params.capture.as, capturedVal);
           }
           context.vars.$ = r;
         } catch (e) {


### PR DESCRIPTION
Is nice to see if one's capture specs are right. You can now see them with `DEBUG=http`.