### PR TITLE
Feature: "pause" and "arrivalCount" support in config.phases

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -100,11 +100,39 @@ function run(script, ee, options) {
   let aggregate = Stats.create();
 
   let phases = _.map(script.config.phases, function(phaseSpec, i) {
+    if (phaseSpec.pause) {
+      return createPausePhase(phaseSpec, ee);
+    }
+
+    if (phaseSpec.arrivalCount) {
+      let task = function(callback) {
+        ee.emit('phaseStarted', {
+          type: 'arrivalCount',
+          name: phaseSpec.name,
+          duration: phaseSpec.duration
+        });
+        const interval = phaseSpec.duration * 1000 / phaseSpec.arrivalCount;
+        const ppStartedAt = process.hrtime();
+        const pp = arrivals.uniform.process(interval, phaseSpec.duration * 1000);
+        pp.on('arrival', function onArrival() {
+          runScenario(script, intermediate, aggregate);
+        });
+        pp.on('finished', function onFinished() {
+          ee.emit('phaseCompleted', {
+            name: phaseSpec.name,
+            duration: phaseSpec.duration
+          });
+          const ppStoppedAt = process.hrtime(ppStartedAt);
+          const ppRanFor = (ppStoppedAt[0] * 1e9) + ppStoppedAt[1];
+          return callback(null);
+        });
+        pp.start();
+      };
+      return task;
+    }
 
     let task = function(callback) {
-
       ee.emit('phaseStarted', {
-        index: i,
         name: phaseSpec.name,
         duration: phaseSpec.duration
       });
@@ -117,7 +145,6 @@ function run(script, ee, options) {
       });
       pp.on('finished', function onFinished() {
         ee.emit('phaseCompleted', {
-          index: i,
           name: phaseSpec.name,
           duration: phaseSpec.duration
         });
@@ -260,6 +287,24 @@ function runScenario(script, intermediate, aggregate) {
       aggregate.completedScenario();
     }
   });
+}
+
+function createPausePhase(spec, ee) {
+  return function task(callback) {
+    ee.emit('phaseStarted', {
+      type: 'pause',
+      name: spec.name,
+      duration: spec.duration
+    });
+    setTimeout(function() {
+      ee.emit('phaseCompleted', {
+        type: 'pause',
+        name: spec.name,
+        duration: spec.duration
+      });
+      return callback(null);
+    }, spec.pause * 1000);
+  };
 }
 
 /**

--- a/test/scripts/arrival_phases.json
+++ b/test/scripts/arrival_phases.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "target": "http://localhost:3003",
+
+    "phases": [
+      {"duration": 20, "arrivalCount": 10},
+      {"pause": 20},
+      {"duration": 20, "arrivalCount": 50}
+    ]
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {"get": {"url": "/"}}
+      ]
+    }
+  ]
+}

--- a/test/test_arrivals.js
+++ b/test/test_arrivals.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const test = require('tape');
+const runner = require('../lib/runner').runner;
+
+test('arrival phases', function(t) {
+  var script = require('./scripts/arrival_phases.json');
+
+  var ee = runner(script);
+
+  ee.on('phaseStarted', function(info) {
+    console.log('Starting phase: %j - %s', info, new Date());
+  });
+  ee.on('phaseCompleted', function() {
+    console.log('Phase completed - %s', new Date());
+  });
+
+  ee.on('done', function(stats) {
+    console.log('%j', stats);
+    t.end();
+  });
+  ee.run();
+});


### PR DESCRIPTION

This PR adds additional options for phase definitions:

1. `{"pause": 10}` - pause for 10 seconds
2. `{"duration": 60, "arrivalCount": 50}` - create 50 users in 60 seconds