### PR TITLE
Fix: include phase index in spec

### DIFF
--- a/lib/phases.js
+++ b/lib/phases.js
@@ -12,9 +12,10 @@ function phaser(phaseSpecs) {
   let ee = new EventEmitter();
 
   let tasks = _.map(phaseSpecs, function(spec, i) {
-    if (!spec.name) {
-      spec.name = i;
+    if (!spec.index) {
+      spec.index = i;
     }
+
     if (spec.arrivalRate && !spec.rampTo) {
       spec.mode = spec.mode || 'poisson';
     }


### PR DESCRIPTION
Fixes "starting phase undefined" message in Minigun CLI