### PR TITLE
Feature: scenario weights

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -8,6 +8,7 @@ const Stats = require('./stats');
 const JSCK = require('jsck');
 const createPhaser = require('./phases');
 const engineUtil = require('./engine_util');
+const wl = require('./weighted-pick');
 
 const Engines = {
   http: {},
@@ -31,6 +32,7 @@ let cancelledRequests = new Measured.Counter();
 
 let compiledScenarios;
 let scenarioEvents;
+let picker;
 
 let Report = {
   intermediate: [],
@@ -194,6 +196,14 @@ function runScenario(script, intermediate, aggregate) {
   // Compile scenarios if needed
   //
   if (!compiledScenarios) {
+    _.each(script.scenarios, function(scenario) {
+      if (!scenario.weight) {
+        scenario.weight = 1;
+      }
+    });
+
+    picker = wl(script.scenarios);
+
     scenarioEvents = new EventEmitter();
     scenarioEvents.on('started', function() {
       pendingScenarios.inc();
@@ -244,8 +254,14 @@ function runScenario(script, intermediate, aggregate) {
   intermediate.newScenario();
   aggregate.newScenario();
 
+  let i = picker()[0];
+
+  debug('picking scenario %s (%s) weight = %s',
+        i,
+        script.scenarios[i].name,
+        script.scenarios[i].weight);
+
   const scenarioStartedAt = process.hrtime();
-  let i = _.random(0, compiledScenarios.length - 1);
   compiledScenarios[i](createContext(script), function(err, context) {
     pendingScenarios.dec();
     if (err) {
@@ -298,13 +314,6 @@ function createContext(script) {
     });
   }
   return result;
-}
-
-/**
- * Returns a scenario picked at random from a list of scenarios.
- */
-function pickScenario(scenarios) {
-  return scenarios[_.random(0, scenarios.length - 1)];
 }
 
 //

--- a/lib/weighted-pick.js
+++ b/lib/weighted-pick.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const l = require('lodash');
+
+module.exports = create;
+
+// naive implementation of selection with replacement
+function create(list) {
+  let dist = l.foldl(list, function(acc, el, i) {
+    for(let j = 0; j < el.weight * 100; j++) {
+      acc.push(i);
+    }
+    return acc;
+  }, []);
+
+  return function() {
+    let i = dist[l.random(0, dist.length - 1)];
+    return [i, list[i]];
+  };
+}
+
+function bench() {
+  const items = [
+    { weight: 1, value: 'a' },
+    { weight: 2, value: 'b' },
+    { weight: 3, value: 'c' },
+    { weight: 4, value: 'd' },
+    { weight: 5, value: 'e' },
+    { weight: 1, value: 'f' },
+    { weight: 2, value: 'g' },
+    { weight: 3, value: 'h' },
+    { weight: 4, value: 'i' },
+    { weight: 5, value: 'j' },
+    { weight: 10, value: 'k' }
+  ];
+
+  const picker = create(items);
+
+  const ITERS = Math.pow(10, 6);
+  const startedAt = Date.now();
+
+  const picks = l.map(
+    l.range(ITERS),
+    function() {
+      let x = picker()[1];
+      return x;
+    });
+
+  const delta = Date.now() - startedAt;
+  console.log('ITERS = %s\ndelta = %s\nITERS/delta = %s',
+    ITERS,
+    delta,
+    Math.round(ITERS / delta));
+
+  const sumWeights = l.foldl(items, function(acc, item) {
+    return acc + item.weight;
+  }, 0);
+
+  console.log('sumWeights = %s', sumWeights);
+
+  l.each(items, function(p) {
+    let count = l.where(picks, {value: p.value}).length;
+    console.log('Count of %s = %s (should be: %s\%, is: %s\%)',
+      p.value,
+      count,
+      Math.round(p.weight / sumWeights * 1000) / 1000,
+      Math.round(count / ITERS * 1000) / 1000);
+  });
+}
+
+if (require.main === module) {
+  bench();
+}

--- a/test/scripts/all_features.json
+++ b/test/scripts/all_features.json
@@ -22,6 +22,7 @@
   },
   "scenarios": [
     {
+      "weight": 10,
       "flow": [
         {"get": {"url": "/pets"}},
         {"think": 1},
@@ -29,6 +30,13 @@
         {"post": {"url": "http://127.0.0.1:3003/pets", "body": "{\"name\": \"{{ name }}\", \"species\": \"{{ species }}\"}" }},
         {"get": {"url": "/pets", "headers": {"x-auth": "overrides-the-value-in-defaults"}}},
         {"post": {"url": "/pets", "json": {"name": "{{ name }}", "species": "{{ species }}"}, "headers": {"user-agent": "minigun"}}}
+      ]
+    },
+    {
+      "weight": 1,
+      "name": "weighted scenario",
+      "flow": [
+        {"get": {"url": "/will404"}}
       ]
     }
   ]

--- a/test/test_complete.js
+++ b/test/test_complete.js
@@ -17,12 +17,6 @@ l.each(SCRIPTS, function(fn) {
   var script = require('./scripts/' + fn);
   test('Script: ' + fn, function(t) {
 
-    // Preconditions
-    t.assert(
-      script.scenarios.length === 1,
-      'Expecting the test script to have one scenario'
-    );
-
     // Set up for expectations
     var completedPhases = 0;
     var startedAt = process.hrtime();


### PR DESCRIPTION
Scenarios can now have associated weights, specified with a `weight` attribute.

Weights are expected to be integers.

If a weight is not specified, it is set to `1`. This means that all existing scripts continue to work in the same manner.

Performance-wise: I am getting ~10k pick operation per 1ms for a list with 11 weighted items on my 1.6 GHz i5 Macbook Air, which is negligible overhead when launching scenarios.