### PR TITLE
Use 'uniform' mode for arrivals by default

### DIFF
--- a/lib/phases.js
+++ b/lib/phases.js
@@ -17,7 +17,7 @@ function phaser(phaseSpecs) {
     }
 
     if (spec.arrivalRate && !spec.rampTo) {
-      spec.mode = spec.mode || 'poisson';
+      spec.mode = spec.mode || 'uniform';
     }
 
     if (spec.pause) {
@@ -117,6 +117,7 @@ function createArrivalRate(spec, ee) {
     ee.emit('phaseStarted', spec);
     const ar = 1000 / spec.arrivalRate;
     const duration = spec.duration * 1000;
+    debug('creating a %s process for arrivalRate', spec.mode);
     const p = arrivals[spec.mode].process(ar, duration);
     p.on('arrival', function() {
       ee.emit('arrival');

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('events').EventEmitter;
 const _ = require('lodash');
 const debug = require('debug')('runner');
+const debugPerf = require('debug')('perf');
 const Measured = require('measured');
 const Stats = require('./stats');
 const JSCK = require('jsck');
@@ -51,9 +52,13 @@ function runner(script, payload, options) {
 
   let opts = _.assign({
     periodicStats: script.config.statsInterval || 10,
-    mode: script.config.mode || 'poisson'
+    mode: script.config.mode || 'uniform'
   },
   options);
+
+  _.each(script.config.phases, function(phaseSpec) {
+    phaseSpec.mode = phaseSpec.mode || script.config.mode;
+  });
 
   if (payload) {
     script.config.payload.data = payload;
@@ -192,6 +197,8 @@ function run(script, ee, options) {
 }
 
 function runScenario(script, intermediate, aggregate) {
+  const start = process.hrtime();
+
   //
   // Compile scenarios if needed
   //
@@ -262,7 +269,11 @@ function runScenario(script, intermediate, aggregate) {
         script.scenarios[i].weight);
 
   const scenarioStartedAt = process.hrtime();
-  compiledScenarios[i](createContext(script), function(err, context) {
+  const scenarioContext = createContext(script);
+  const finish = process.hrtime(start);
+  const runScenarioDelta = (finish[0] * 1e9) + finish[1];
+  debugPerf('runScenarioDelta: %s', Math.round(runScenarioDelta / 1e6 * 100) / 100);
+  compiledScenarios[i](scenarioContext, function(err, context) {
     pendingScenarios.dec();
     if (err) {
       debug(err);


### PR DESCRIPTION
This combined with the timer fix in `arrivals` v1.0.2 makes the number of
scenarios launched in a phase consistent and predictable.