### PR TITLE
Feature: allow multiple payload definitions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,7 +22,6 @@
     "no-unused-expressions": 1,
     "no-native-reassign": 1,
     "no-fallthrough": 1,
-    "handle-callback-err": 1,
     "camelcase": 1,
     "no-unused-vars": 1,
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -61,7 +61,16 @@ function runner(script, payload, options) {
   });
 
   if (payload) {
-    script.config.payload.data = payload;
+    if (_.isArray(payload[0])) {
+      script.config.payload = [
+        {
+          fields: script.config.payload.fields,
+          data: payload
+        }
+      ];
+    } else {
+      script.config.payload = payload;
+    }
   }
 
   let runnableScript = _.cloneDeep(script);
@@ -306,13 +315,23 @@ function createContext(script) {
     }
   };
   let result = _.cloneDeep(INITIAL_CONTEXT);
-  if (script.config.payload && script.config.payload.data) {
-    let i = _.random(0, script.config.payload.data.length - 1);
-    let row = script.config.payload.data[i];
-    _.each(script.config.payload.fields, function(fieldName, j) {
-      result.vars[fieldName] = row[j];
+
+  //
+  // variables from payloads
+  //
+  if (script.config.payload) {
+    _.each(script.config.payload, function(el) {
+      let i = _.random(0, el.data.length - 1);
+      let row = el.data[i];
+      _.each(el.fields, function(fieldName, j) {
+        result.vars[fieldName] = row[j];
+      });
     });
   }
+
+  //
+  // inline variables
+  //
   if (script.config.variables) {
     _.each(script.config.variables, function(v, k) {
       let val;

--- a/lib/schemas/minigun_test_script.json
+++ b/lib/schemas/minigun_test_script.json
@@ -14,7 +14,7 @@
           "type": "array"
         },
         "payload": {
-          "type": "object"
+          "anyOf": [ {"type": "object"}, {"type": "array"}]
         },
         "defaults": {
           "type": "object"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ws": "0.8.0"
   },
   "devDependencies": {
+    "csv-parse": "1.0.1",
     "eslint": "^0.24.0",
     "good": "6.4.0",
     "good-console": "5.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,9 @@
 require('./unit/index');
+require('./test_multiple_payloads');
+require('./test_complete');
 
 //require('./test_worker_http');
 //require('./test_environments.js');
-require('./test_complete');
 //require('./test_capture');
 //require('./test_arrivals');
 //require('./test_think');

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 require('./unit/index');
 require('./test_multiple_payloads');
-require('./test_complete');
+require('./test_misc');
 
 //require('./test_worker_http');
 //require('./test_environments.js');

--- a/test/scripts/multiple_payloads.json
+++ b/test/scripts/multiple_payloads.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:3003",
+      "phases": [
+        { "duration": 10, "arrivalRate": 5 }
+      ],
+      "payload": [
+        {
+          "path": "../pets.csv",
+          "fields": ["species", "name"]
+        },
+        {
+          "path": "../urls.csv",
+          "fields": ["url"]
+        }
+      ]
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {"get": {"url": "{{{url}}}"}},
+        {"get": {"url": "/{{{name}}}"}},
+        {"post": {"url": "/pets", "json": {"name": "{{ name }}", "species": "{{ species }}"}}}
+      ]
+    }
+  ]
+}
+
+
+
+

--- a/test/scripts/single_payload.json
+++ b/test/scripts/single_payload.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:3003",
+      "phases": [
+        { "duration": 10, "arrivalRate": 5 }
+      ],
+      "payload": {
+        "fields": ["species", "name"]
+      }
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {"get": {"url": "/{{{name}}}"}},
+        {"post": {"url": "/pets", "json": {"name": "{{ name }}", "species": "{{ species }}"}}}
+      ]
+    }
+  ]
+}
+
+
+
+

--- a/test/test_misc.js
+++ b/test/test_misc.js
@@ -8,7 +8,6 @@ var url = require('url');
 var SCRIPTS = [
   'hello.json',
   'multiple_phases.json',
-  'all_features.json',
   'large_payload.json'
   ];
 

--- a/test/test_multiple_payloads.js
+++ b/test/test_multiple_payloads.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('tape');
+const runner = require('../lib/runner').runner;
+const l = require('lodash');
+const url = require('url');
+const fs = require('fs');
+const path = require('path');
+const csv = require('csv-parse');
+const async = require('async');
+
+test('multiple_payloads', function(t) {
+  const fn = './scripts/multiple_payloads.json';
+  let script = require(fn);
+
+  async.map(
+    script.config.payload,
+    function(item, callback) {
+      let payloadFile = path.resolve(
+        path.dirname(path.join(__dirname, fn)),
+        item.path);
+
+      let data = fs.readFileSync(payloadFile, 'utf-8');
+      csv(data, function(err, parsedData) {
+        item.data = parsedData;
+        return callback(err, item);
+      });
+    },
+    function(err, results) {
+      if (err) {
+        console.log(err);
+        t.fail(err);
+      }
+
+      let ee = runner(script, script.config.payload, {});
+
+      ee.on('phaseStarted', function(x) {
+        t.ok(x, 'phaseStarted event emitted');
+      });
+
+      ee.on('phaseCompleted', function(x) {
+        t.ok(x, 'phaseCompleted event emitted');
+      });
+
+      ee.on('stats', function(stats) {
+        t.ok(stats, 'intermediate stats event emitted');
+      });
+
+      ee.on('done', function(stats) {
+        let requests = stats.aggregate.requestsCompleted;
+        let scenarios = stats.aggregate.scenariosCompleted;
+        t.assert(stats.aggregate.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
+        t.assert(stats.aggregate.codes[200] > 0, 'There are some 200s (URLs constructed from urls.csv)');
+        t.assert(stats.aggregate.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
+        t.end();
+      });
+
+      ee.run();
+    });
+});

--- a/test/test_multiple_payloads.js
+++ b/test/test_multiple_payloads.js
@@ -9,6 +9,43 @@ const path = require('path');
 const csv = require('csv-parse');
 const async = require('async');
 
+test('single payload', function(t) {
+  const fn = './scripts/single_payload.json';
+  let script = require(fn);
+
+  let data = fs.readFileSync(path.join(__dirname, 'pets.csv'));
+  csv(data, function(err, parsedData) {
+    if (err) {
+      t.fail(err);
+    }
+
+    let ee = runner(script, parsedData, {});
+
+    ee.on('phaseStarted', function(x) {
+      t.ok(x, 'phaseStarted event emitted');
+    });
+
+    ee.on('phaseCompleted', function(x) {
+      t.ok(x, 'phaseCompleted event emitted');
+    });
+
+    ee.on('stats', function(stats) {
+      t.ok(stats, 'intermediate stats event emitted');
+    });
+
+    ee.on('done', function(stats) {
+      let requests = stats.aggregate.requestsCompleted;
+      let scenarios = stats.aggregate.scenariosCompleted;
+      t.assert(stats.aggregate.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
+      t.assert(stats.aggregate.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
+      t.end();
+    });
+
+    ee.run();
+  });
+});
+
+
 test('multiple_payloads', function(t) {
   const fn = './scripts/multiple_payloads.json';
   let script = require(fn);

--- a/test/urls.csv
+++ b/test/urls.csv
@@ -1,0 +1,7 @@
+/pets
+/pets
+/pets
+/pets
+/pets
+/pets
+/pets


### PR DESCRIPTION
`script.config.payload` can now be either an object (current behavior) or an array
of objects with these attributes:

- `path` - path to the CSV file, relative to the test script, used by the CLI
- `fields` - CSV field names
- `data` - rows from the CSV file - populated by the CLI (or another user of this library)